### PR TITLE
kill contact page

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -54,9 +54,6 @@ const Navbar = class extends React.Component {
         <Link className="navbar-item" to="/about">
           About
         </Link>
-        <Link className="navbar-item" to="/contact">
-          Contact
-        </Link>
       </div>
       <div className="navbar-end has-text-centered">
         <Link className="navbar-item" to="/">


### PR DESCRIPTION
This PR removes the contact page from our site. Note that the contact page files still exist in case we add a contact page in the future, but they're no longer accessible from the navbar.