### PR TITLE
Add Projects page v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7053,13 +7053,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7072,18 +7070,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7186,8 +7181,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7197,7 +7191,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7210,7 +7203,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7310,8 +7302,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7321,7 +7312,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7427,7 +7417,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -16520,6 +16509,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-lines-ellipsis": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-lines-ellipsis/-/react-lines-ellipsis-0.14.0.tgz",
+      "integrity": "sha512-zJf+evlugAQ42zwHYbsR/P9SSx2UrT4opWwY8JXPNIZTVVxjqTt2+91Csx3ya0xSesj7E/EgfUbtDfU03uylXQ=="
     },
     "react-modal": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "disqus-react": "^1.0.5",
     "gatsby": "^2.0.66",
     "gatsby-image": "^2.0.23",
+    "gatsby-plugin-antd": "2.0.2",
     "gatsby-plugin-netlify": "^2.0.6",
     "gatsby-plugin-netlify-cms": "^3.0.9",
     "gatsby-plugin-purgecss": "^3.1.0",
     "gatsby-plugin-react-helmet": "^3.0.4",
     "gatsby-plugin-sass": "^2.0.7",
     "gatsby-plugin-sharp": "^2.0.15",
-    "gatsby-plugin-antd": "2.0.2",
     "gatsby-remark-copy-linked-files": "^2.0.7",
     "gatsby-remark-images": "^3.0.1",
     "gatsby-remark-relative-images": "^0.2.2",
@@ -31,6 +31,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
+    "react-lines-ellipsis": "^0.14.0",
     "uuid": "^3.2.1"
   },
   "keywords": [

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -9,27 +9,27 @@ const Navbar = class extends React.Component {
    const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
     // Check if there are any navbar burgers
    if ($navbarBurgers.length > 0) {
- 
+
      // Add a click event on each of them
      $navbarBurgers.forEach( el => {
        el.addEventListener('click', () => {
- 
+
          // Get the target from the "data-target" attribute
          const target = el.dataset.target;
          const $target = document.getElementById(target);
- 
+
          // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
          el.classList.toggle('is-active');
          $target.classList.toggle('is-active');
- 
+
        });
      });
    }
  }
- 
+
  render() {
    return (
-  
+
   <nav className="navbar is-transparent" role="navigation" aria-label="main-navigation">
     <div className="container">
       <div className="navbar-brand">
@@ -48,7 +48,7 @@ const Navbar = class extends React.Component {
         <Link className="navbar-item" to="/">
           Create a Project
         </Link>
-        <Link className="navbar-item" to="/">
+        <Link className="navbar-item" to="/projects">
           View All Projects
         </Link>
         <Link className="navbar-item" to="/about">

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -44,4 +44,8 @@ $body-color: #333
 .margin-top-0
   margin-top: 0 !important
 
+.project-title
+  //padding-left: 20px
+  color: #000000
+
 @import "~bulma"

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -75,7 +75,7 @@ const ProjectPage = ({ data }) => (
                 <Link style={{display:'inline-block', color: '#1C2833', marginRight: '5%'}} to={`/${document.node.id}`}>{document.node.project_name}</Link>
                 </h3>
                 <h4 className="has-text-weight-normal is-size-5 is-size-6" style={{color: '#1C2833'}}>
-                <Link to={document.node.profile.profile_name}><i>Sponsored by {document.node.profile.profile_name}</i></Link>
+                <Link style={{color: '#1C2833'}} to={`/${document.node.id}`}><i>Sponsored by </i></Link>
                 </h4>
                 <LinesEllipsis
                     text={document.node.project_description}
@@ -163,9 +163,6 @@ export const pageQuery = graphql`
   	            }
   	          }
   	        }
-          profile {
-              profile_name
-          }
         }
       }
     }

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -1,0 +1,173 @@
+import React from 'react'
+import { Link, graphql } from 'gatsby'
+import Img from 'gatsby-image'
+import Layout from '../components/Layout.js'
+import Navbar from '../components/Navbar.js'
+import ReactDOM from "react-dom";
+import { version, Button } from 'antd';
+import "antd/dist/antd.css";
+import { Input } from 'antd';
+import { Row, Col } from 'antd';
+import { Menu, Dropdown, Icon, message} from 'antd';
+import { Pagination } from 'antd';
+import LinesEllipsis from 'react-lines-ellipsis'
+
+
+const ProjectPage = ({ data }) => (
+  <Layout>
+  <section className="section">
+    <div className="container">
+      <h1 className="has-text-weight-bold is-size-1" style={{color: '#1C2833'}}>Explore Projects</h1>
+      <hr style={{
+            color:'#1C2833',
+            backgroundColor: '#1C2833',
+            height: 5
+          }}/>
+
+      <br></br>
+
+      {/*
+        The block of code below contains the frontent components for search
+        and filtering. These features are not functioning so they've been
+        commented out until the functionality can be completed
+      */}
+
+      {/*}
+      <Row type="flex" justify="start">
+          <Col span={15}>
+          <Dropdown overlay={thingys}>
+            <Button style={{marginLeft: 8}}>
+              Thingys per page <Icon type="down" />
+            </Button>
+          </Dropdown>
+          </Col>
+          <Col span={3}>
+
+          <Dropdown overlay={sort}>
+            <Button style={{marginLeft: 8}}>
+              Sort by ... <Icon type="down" />
+            </Button>
+          </Dropdown>
+
+          </Col>
+          <Col span={3}>
+              <Search
+                  placeholder="search projects"
+                  onSearch={value => console.log(value)}
+                  style={{ width: 300}}
+                  enterbutton
+              />
+          </Col>
+      </Row>
+
+
+      <br></br>
+      <br></br>
+      */}
+
+      <div className="projects">
+        <Row type="flex" justify="center" align="top" gutter={24}>
+          {data.allStrapiProject.edges.map(document => (
+            <Col xs={15} sm={12} md={10} lg={8} xl={6}>
+              <li style={{display:'inline-block'}} key={document.node.id}>
+                <Link to={`/${document.node.id}`}><Img imgStyle={{padding:'0px'}} fixed={document.node.project_image.childImageSharp.fixed} /></Link>
+                <h3 className="has-text-weight-bold is-size-5">
+                <Link style={{display:'inline-block', color: '#1C2833', marginRight: '5%'}} to={`/${document.node.id}`}>{document.node.project_name}</Link>
+                </h3>
+                <h4 className="has-text-weight-normal is-size-5 is-size-6" style={{color: '#1C2833'}}>
+                <Link to={document.node.profile.profile_name}><i>Sponsored by {document.node.profile.profile_name}</i></Link>
+                </h4>
+                <LinesEllipsis
+                    text={document.node.project_description}
+                    maxLine='2'
+                    ellipsis='...'
+                    trimRight
+                    basedOn='letters'
+                />
+                <br></br>
+                <br></br>
+              </li>
+            </Col>
+          ))}
+        </Row>
+      </div>
+      {/* this block of code contains a frontend pagination feature that has
+        not been implemented yet
+
+      <Row type="flex" justify="center" align="top">
+        <Col span={10}>
+            <Pagination showQuickJumper defaultCurrent={1} total={200} onChange={onChange} />
+        </Col>
+      </Row>
+      */}
+    </div>
+  </section>
+
+  </Layout>
+)
+
+export default ProjectPage
+
+{/*
+  The block of code below contains the frontent components for search
+  and filtering. These features are not functioning so they've been
+  commented out until the functionality can be completed
+*/}
+
+{/*
+const Search = Input.Search;
+
+const sort = (
+  <Menu onClick={handleMenuClick}>
+    <Menu.Item key="1"><Icon type="hourglass" />Most Recently Created</Menu.Item>
+    <Menu.Item key="2"><Icon type="hourglass" />Most Recently Modified</Menu.Item>
+  </Menu>
+);
+
+const thingys = (
+  <Menu onClick={handleMenuClick}>
+    <Menu.Item key="1"><Icon type="frown" />1</Menu.Item>
+    <Menu.Item key="2"><Icon type="meh" rotate="170" />2</Menu.Item>
+    <Menu.Item key="2"><Icon type="smile" />2000000000</Menu.Item>
+  </Menu>
+);
+
+function handleButtonClick(e) {
+  message.info('Click on left button.');
+  console.log('click left button', e);
+}
+
+function handleMenuClick(e) {
+  message.info('Click on menu item.');
+  console.log('click', e);
+}
+
+function onChange(pageNumber) {
+  console.log('Page: ', pageNumber);
+}
+
+*/}
+
+export const pageQuery = graphql`
+  query ProjectQuery {
+    allStrapiProject {
+      edges {
+        node {
+          id
+          project_name
+          project_description
+  	      project_image {
+  	         childImageSharp {
+  	            fixed(width:300, height:200) {
+  		             ...GatsbyImageSharpFixed
+  	            }
+  	          }
+  	        }
+          profile {
+              profile_name
+          }
+        }
+      }
+    }
+  }
+  `

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -75,15 +75,15 @@ const ProjectPage = ({ data }) => (
                 <Link style={{display:'inline-block', color: '#1C2833', marginRight: '5%'}} to={`/${document.node.id}`}>{document.node.project_name}</Link>
                 </h3>
                 <h4 className="has-text-weight-normal is-size-5 is-size-6" style={{color: '#1C2833'}}>
-                <Link style={{color: '#1C2833'}} to={`/${document.node.id}`}><i>Sponsored by </i></Link>
+                <Link style={{color: '#1C2833'}} to={`/${document.node.profiles.profile_name}`}><i>Sponsored by {document.node.profiles.profile_name}</i></Link>
                 </h4>
-                <LinesEllipsis
+                <Link style={{color: '#1C2833'}} to={`/${document.node.id}`}><LinesEllipsis
                     text={document.node.project_description}
-                    maxLine='2'
+                    maxLine='3'
                     ellipsis='...'
                     trimRight
                     basedOn='letters'
-                />
+                /></Link>
                 <br></br>
                 <br></br>
               </li>
@@ -156,6 +156,9 @@ export const pageQuery = graphql`
           id
           project_name
           project_description
+          project_goals
+          project_holy_goals
+          project_timeline
   	      project_image {
   	         childImageSharp {
   	            fixed(width:300, height:200) {
@@ -163,6 +166,9 @@ export const pageQuery = graphql`
   	            }
   	          }
   	        }
+          profiles {
+            profile_name
+          }
         }
       }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds the projects page which contains a grid format of all projects in the strapi database.  It also updates the list of packages to include a react functionality that helps to format the descriptions.  The pages uses the ant component library for the grid formatting and UI elements.

**What needs to be documented once your changes are merged?**
This code contains some commented out blocks that have certain UI elements like search/sorting/pagination/etc. These are not functioning which is why they have been commented out. The changes that need to be made are documented in the following trello ticket:
<blockquote class="trello-card"><a href="https://trello.com/c/WltRAaWl/179-add-functionality-for-projects-page">Add functionality for Projects page</a></blockquote>
