### PR TITLE
Navbar fix

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Link, withPrefix } from 'gatsby'
+
+
+const Footer = class extends React.Component {
+  render() {
+    return (
+      <footer className="footer has-background-black has-text-white-ter">
+        <div className="content has-text-centered">
+          <Link to="/">
+            <img
+              src={withPrefix('img/atom.svg')}
+              alt="Logo"
+              style={{ width:"240px","height":"70px" }}
+            />
+          </Link>
+        </div>
+        <div className="content has-text-centered has-background-black has-text-white-ter">
+          <div className="container has-background-black has-text-white-ter">
+            <div className="columns is-centered">
+              <div className="column is-4">
+                <section className="menu">
+                    <Link to="/" className="navbar-item">
+                      Create a Project
+                    </Link>
+                </section>
+              </div>
+              <div className="column is-4">
+                <section>
+                    <Link className="navbar-item" to="/projects" style={{textAlign:'centered'}}>
+                      View All Projects
+                    </Link>
+                </section>
+              </div>
+              <div className="column is-4">
+                <section>
+                    <Link className="navbar-item" to="/about">
+                      About Us
+                    </Link>
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    )
+  }
+}
+
+export default Footer

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet'
 import { StaticQuery, graphql } from "gatsby"
 
 import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
 import './all.sass'
 
 const TemplateWrapper = ({ children }) => (
@@ -38,6 +39,7 @@ const TemplateWrapper = ({ children }) => (
         </Helmet>
         <Navbar />
         <div>{children}</div>
+        <Footer />
       </div>
     )}
   />

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { Link, graphql } from 'gatsby'
 import Layout from '../components/Layout'
 import PreviewCompatibleImage from '../components/PreviewCompatibleImage'
-import Navbar from '../components/Navbar';
 import SectionHeader from '../components/SectionHeader';
 
 
@@ -98,7 +97,6 @@ export const AboutPageTemplate = ({
             </div>
           </div>
         </div>
-        <Navbar />
       </div>
     </section>
   )


### PR DESCRIPTION
This PR removes the double-navbar that breaks the hamburger menu. ("There can be only one!") Anyways, I also resurrected the Footer component as a replacement for bottom nav. We may want to play with the content (I'd like a "complete" logo instead of just the atom symbol, for a start), but this should hopefully resolve the last of the weird CSS behavior.