### PR TITLE
Added sponsor name text to projects #59

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,7 +28,7 @@ module.exports = {
         //apiURL: 'http://localhost:1337',
         apiURL: 'http://techconnect-api.ddns.net:1337',
         contentTypes: [ // List of the Content Types you want to be able to request from Gatsby.
-          'project',
+          'project'
         ],
         queryLimit: 1000,
         loginData: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,6 @@ module.exports = {
         apiURL: 'http://techconnect-api.ddns.net:1337',
         contentTypes: [ // List of the Content Types you want to be able to request from Gatsby.
           'project',
-          'sponsor',
         ],
         queryLimit: 1000,
         loginData: {

--- a/src/components/ProjectTile.js
+++ b/src/components/ProjectTile.js
@@ -11,7 +11,7 @@ const ProjectTile = ({ data }) => (
       <Link className="has-text-primary" style={{display:'inline-block'}} to={`/${data.id}`}>{data.project_name}</Link>
     </h3>
     <h4 className="has-text-weight-normal is-size-5 is-size-6">
-      <i>Sponsored by {data.sponsor.sponsor_name}</i>
+      <i>Sponsored by {data.sponsor_name}</i>
     </h4>
     <Link className="has-text-primary" to={`/${data.id}`}>
       <LinesEllipsis

--- a/src/components/ProjectTile.js
+++ b/src/components/ProjectTile.js
@@ -11,7 +11,7 @@ const ProjectTile = ({ data }) => (
       <Link className="has-text-primary" style={{display:'inline-block'}} to={`/${data.id}`}>{data.project_name}</Link>
     </h3>
     <h4 className="has-text-weight-normal is-size-5 is-size-6">
-      <i>Sponsored by Someone</i>
+      <i>Sponsored by {data.sponsor.sponsor_name}</i>
     </h4>
     <Link className="has-text-primary" to={`/${data.id}`}>
       <LinesEllipsis

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,6 +53,9 @@ export const pageQuery = graphql`
           id
           project_name
           project_description
+          sponsor {
+            sponsor_name
+          }
           project_image {
             childImageSharp {
                fluid(maxWidth:300, maxHeight:200, quality:90, toFormat: JPG) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -53,9 +53,7 @@ export const pageQuery = graphql`
           id
           project_name
           project_description
-          sponsor {
-            sponsor_name
-          }
+          sponsor_name
           project_image {
             childImageSharp {
                fluid(maxWidth:300, maxHeight:200, quality:90, toFormat: JPG) {

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -38,6 +38,9 @@ export const pageQuery = graphql`
           project_blurb
           project_holy_goals
           project_timeline
+          sponsor {
+            sponsor_name
+          }
           project_image {
              childImageSharp {
                 fluid(maxWidth:300, maxHeight:200, quality:90, toFormat:JPG) {

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -38,9 +38,7 @@ export const pageQuery = graphql`
           project_blurb
           project_holy_goals
           project_timeline
-          sponsor {
-            sponsor_name
-          }
+          sponsor_name
           project_image {
              childImageSharp {
                 fluid(maxWidth:300, maxHeight:200, quality:90, toFormat:JPG) {

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -22,7 +22,7 @@ const ProjectTemplate = ({ data }) => (
               <div style={{display:'inline', padding: '5%'}}>
                 <h1 className="has-text-weight-bold is-size-2 has-text-primary">{data.strapiProject.project_name}</h1>
                 <hr className="horizontal-rule" />
-                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by <a class="is-link" href={data.strapiProject.sponsor_website}>{data.strapiProject.sponsor_name}</a></p>
+                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by <a className="is-link" href={data.strapiProject.sponsor_website}>{data.strapiProject.sponsor_name}</a></p>
                 <br/>
                 <br/>
                 <br/>

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link, graphql } from 'gatsby'
+import { graphql } from 'gatsby'
 import Layout from '../components/Layout.js'
 import PreviewCompatibleImage from '../components/PreviewCompatibleImage.js'
 import Disqus from 'disqus-react'

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -22,7 +22,7 @@ const ProjectTemplate = ({ data }) => (
               <div style={{display:'inline', padding: '5%'}}>
                 <h1 className="has-text-weight-bold is-size-2 has-text-primary">{data.strapiProject.project_name}</h1>
                 <hr className="horizontal-rule" />
-                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by Someone</p>
+                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by {data.strapiProject.sponsor.sponsor_name}</p>
                 <br/>
                 <br/>
                 <br/>
@@ -97,6 +97,9 @@ export const pageQuery = graphql`
   query ProjectTemplate ($id: String!) {
     strapiProject(id: {eq: $id}) {
       project_name
+      sponsor {
+        sponsor_name
+      }
       project_image {
         childImageSharp {
           fluid(maxWidth:700, maxHeight:470, quality:90, toFormat:JPG) {

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -22,7 +22,7 @@ const ProjectTemplate = ({ data }) => (
               <div style={{display:'inline', padding: '5%'}}>
                 <h1 className="has-text-weight-bold is-size-2 has-text-primary">{data.strapiProject.project_name}</h1>
                 <hr className="horizontal-rule" />
-                <a className="has-text-primary" style={{paddingBottom: '20px'}} href={data.strapiProject.sponsor_website}>Sponsored by {data.strapiProject.sponsor_name}</a>
+                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by <a class="is-link" href={data.strapiProject.sponsor_website}>{data.strapiProject.sponsor_name}</a></p>
                 <br/>
                 <br/>
                 <br/>

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -22,7 +22,7 @@ const ProjectTemplate = ({ data }) => (
               <div style={{display:'inline', padding: '5%'}}>
                 <h1 className="has-text-weight-bold is-size-2 has-text-primary">{data.strapiProject.project_name}</h1>
                 <hr className="horizontal-rule" />
-                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by {data.strapiProject.sponsor.sponsor_name}</p>
+                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by {data.strapiProject.sponsor_name}</p>
                 <br/>
                 <br/>
                 <br/>
@@ -97,9 +97,7 @@ export const pageQuery = graphql`
   query ProjectTemplate ($id: String!) {
     strapiProject(id: {eq: $id}) {
       project_name
-      sponsor {
-        sponsor_name
-      }
+      sponsor_name
       project_image {
         childImageSharp {
           fluid(maxWidth:700, maxHeight:470, quality:90, toFormat:JPG) {

--- a/src/templates/specific-project.js
+++ b/src/templates/specific-project.js
@@ -22,7 +22,7 @@ const ProjectTemplate = ({ data }) => (
               <div style={{display:'inline', padding: '5%'}}>
                 <h1 className="has-text-weight-bold is-size-2 has-text-primary">{data.strapiProject.project_name}</h1>
                 <hr className="horizontal-rule" />
-                <p className="has-text-primary" style={{paddingBottom: '20px'}}>Sponsored by {data.strapiProject.sponsor_name}</p>
+                <a className="has-text-primary" style={{paddingBottom: '20px'}} href={data.strapiProject.sponsor_website}>Sponsored by {data.strapiProject.sponsor_name}</a>
                 <br/>
                 <br/>
                 <br/>
@@ -98,6 +98,7 @@ export const pageQuery = graphql`
     strapiProject(id: {eq: $id}) {
       project_name
       sponsor_name
+      sponsor_website
       project_image {
         childImageSharp {
           fluid(maxWidth:700, maxHeight:470, quality:90, toFormat:JPG) {


### PR DESCRIPTION
## Changes
- Added sponsor text to appropriate fields #59 #72 
  - Added sponsor text to `ProjectTile.js`
  - Added sponsor text to `specific-project.js`
- Added link to sponsor's website in `specific-project.js`
  - **Note:** This assumes the website link is a required field. Else, it will just link to the current page. Should remove link functionality if no website link provided if this is the case.
- Removed unused 'Link' import #64 